### PR TITLE
Index view for Computer ready for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ Human Resources can add a new department by clicking Create New link on the View
 ## Employee Index/List View
     To see the Employee Index view, click on the Employee tab in the navbar in the upper portion of the screen (while the app is running). If all is working correctly, you should see a nicely formatted table that has a column for First Name Last Name and Department Name. Each of these columns should be filled with the corresponding information that is sourced from the database. On the right of each row, for each Employee, you should see a hyperlink for ```Detail``` and ```Edit```. Above the First Name column, there should be a hyperlink for ```Create New```. 
 
+## Computer
+
+## Computer Index/List View
+    To see the Computer Index view, click on the Computer tab in the navbar in the upper portion of the screen (while the app is running). If all is working correctly, you should see a nicely formatted table that has a column for Make, Model and Working. Each of these columns should be filled with the corresponding information that is sourced from the database. On the right of each row, for each Computer, you should see a hyperlink for ```Detail``` and ```Delete```.  
+
+
+

--- a/WorkforceManagement/WorkforceManagement/Controllers/ComputerController.cs
+++ b/WorkforceManagement/WorkforceManagement/Controllers/ComputerController.cs
@@ -36,7 +36,7 @@ namespace WorkforceManagement.Controllers
             using (IDbConnection conn = Connection)
             {
                 IEnumerable<Computer> computers = await conn.QueryAsync<Computer>(
-                    "select ModelName, Manufacturer, Working from Computer;"
+                    "select ComputerId, ModelName, Manufacturer, Working from Computer;"
                 );
                 return View(computers);
             }

--- a/WorkforceManagement/WorkforceManagement/Controllers/ComputerController.cs
+++ b/WorkforceManagement/WorkforceManagement/Controllers/ComputerController.cs
@@ -1,18 +1,45 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Dapper;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using WorkforceManagement.Models;
 
 namespace WorkforceManagement.Controllers
 {
     public class ComputerController : Controller
     {
-        // GET: Computer
-        public ActionResult Index()
+        private readonly IConfiguration _config;
+
+        public ComputerController(IConfiguration config)
         {
-            return View();
+            _config = config;
+        }
+
+        public IDbConnection Connection
+        {
+            get
+            {
+                return new SqlConnection(_config.GetConnectionString("DefaultConnection"));
+            }
+        }
+        // Author: Evan Lusky
+        // Simple dapper query for Computer
+        // Returns and IEnumerable of Computer objects to pass to View.
+        public async Task<IActionResult> Index()
+        {
+            using (IDbConnection conn = Connection)
+            {
+                IEnumerable<Computer> computers = await conn.QueryAsync<Computer>(
+                    "select ModelName, Manufacturer, Working from Computer;"
+                );
+                return View(computers);
+            }
         }
 
         // GET: Computer/Details/5

--- a/WorkforceManagement/WorkforceManagement/Views/Computer/Index.cshtml
+++ b/WorkforceManagement/WorkforceManagement/Views/Computer/Index.cshtml
@@ -1,0 +1,49 @@
+﻿@*Author: Evan Lusky
+    Razor template for List associated with Computer model.  Removed a few lines to only show pertinent information.*@
+
+@model IEnumerable<WorkforceManagement.Models.Computer>
+
+@{
+    ViewData["Title"] = "Index";
+}
+
+<h2>Computers</h2>
+
+@*<p>
+    <a asp-action="Create">Create New</a>
+</p>*@
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.Working)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.ModelName)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Manufacturer)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            <th>
+                @Html.DisplayFor(modelItem => item.Working)
+            </th>
+            <td>
+                @Html.DisplayFor(modelItem => item.ModelName)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Manufacturer)
+            </td>
+            <td>
+                @Html.ActionLink("Details", "Details", new { id = item.ComputerId }) |
+                @Html.ActionLink("Delete", "Delete", new { id = item.ComputerId })
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/WorkforceManagement/WorkforceManagement/Views/Computer/Index.cshtml
+++ b/WorkforceManagement/WorkforceManagement/Views/Computer/Index.cshtml
@@ -34,13 +34,12 @@
                 @Html.DisplayFor(modelItem => item.Working)
             </th>
             <td>
-                @Html.DisplayFor(modelItem => item.ModelName)
+                @Html.ActionLink($"{item.ModelName}", "Details", new { id = item.ComputerId })
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.Manufacturer)
             </td>
             <td>
-                @Html.ActionLink("Details", "Details", new { id = item.ComputerId }) |
                 @Html.ActionLink("Delete", "Delete", new { id = item.ComputerId })
             </td>
         </tr>


### PR DESCRIPTION
# Description
 This implements the List view for the Computer table.  It also adds a section in the documentation on how to access the computer table.
 Fixes #16 
 ## Type of change
 Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
 # Testing Instructions
 Start SQL Server Management Studio

Run BangazonDatabaseCreateSeed.sql in SSMS

Update the appsetting.json in Visual Studio community to reflect your desktop and your server

In the terminal, git fetch --all and git checkout el-computer-idx to switch branches

Start the program by cd'ing into the WorkforceManagement (make sure you are deep enough, the .sln file is a few WorkforceManagement directories deep) and using the command dotnet run.

Once the program is running, navigate to your browser and go to the localhost address shown in the command prompt that opens up when you run the program. Click on the Computers link in the navbar, and you should see a list with all Computers in the database.  There should be three, and each should have a details and delete button, neither of which should currently work.
 # Checklist:
 - [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
